### PR TITLE
docs: Add test plans for background job status updates

### DIFF
--- a/oktryitnow.md
+++ b/oktryitnow.md
@@ -1,0 +1,213 @@
+# Test: Background Jobs with Status Updates (Ollama Local Models)
+
+**Objective:** Verify that `ferri run` jobs properly transition from "Running" to "Completed" status for local Ollama models.
+
+**Note:** Remote model support (`--model gemini`) is not yet implemented for background jobs.
+
+---
+
+## Prerequisites
+
+1. Rebuild and install `ferri`:
+   ```bash
+   cd /Users/jorgeajimenez/repos/ferri
+   cargo build --release
+   cargo install --path .
+   ```
+
+2. Ensure Ollama is running with a model pulled:
+   ```bash
+   ollama pull gemma:2b
+   ```
+
+---
+
+## Setup: Clean Test Environment
+
+```bash
+# Create fresh test directory
+mkdir -p /tmp/ferri-jobs-test-$(date +%s)
+cd /tmp/ferri-jobs-test-$(date +%s)
+
+# Initialize ferri
+ferri init
+```
+
+---
+
+## Configure Ollama Model
+
+```bash
+# Add local Ollama model
+ferri models add gemma --provider ollama --model-name gemma:2b
+
+# Verify model is registered
+ferri models ls
+```
+
+---
+
+## Test 1: Simple Local Job
+
+```bash
+# Run a quick local job
+ferri run --model gemma -- "Write a haiku about Rust programming"
+
+# Immediately check status (should show "Running")
+ferri ps
+
+# Wait 5 seconds for completion
+sleep 5
+
+# Check status again (should show "Completed")
+ferri ps
+
+# Get the job ID from the last run
+JOB_ID=$(cat .ferri/jobs.json | grep '"id"' | tail -1 | cut -d'"' -f4)
+
+# Retrieve the output
+ferri yank $JOB_ID
+```
+
+**Expected Results:**
+- ✅ Job initially shows "Running" in `ferri ps`
+- ✅ After completion, job shows "Completed" in `ferri ps`
+- ✅ `ferri yank` returns the haiku output
+
+---
+
+## Test 2: Multiple Concurrent Jobs
+
+```bash
+# Launch 3 jobs at once
+ferri run --model gemma -- "Name 3 Rust crates for web development"
+ferri run --model gemma -- "What is cargo?"
+ferri run --model gemma -- "Explain borrowing in one sentence"
+
+# Check all are running
+ferri ps
+
+# Wait for completion
+sleep 8
+
+# Verify all completed
+ferri ps
+
+# View all outputs
+cat .ferri/jobs.json | grep '"id"' | tail -3 | cut -d'"' -f4 | while read job; do
+  echo "=== $job ==="
+  ferri yank $job
+  echo ""
+done
+```
+
+**Expected Results:**
+- ✅ All 3 jobs show "Running" initially
+- ✅ All 3 transition to "Completed"
+- ✅ All outputs are retrievable
+
+---
+
+## Test 3: Long-Running Job with Real-Time Status Checks
+
+```bash
+# Start a longer generation
+ferri run --model gemma -- "Write a 300-word story about a developer debugging code at 3am"
+
+# Check status multiple times while it runs
+ferri ps
+sleep 3
+ferri ps
+sleep 3
+ferri ps
+sleep 5
+
+# Final check (should be completed)
+ferri ps
+
+# Get output
+JOB_ID=$(cat .ferri/jobs.json | grep '"id"' | tail -1 | cut -d'"' -f4)
+ferri yank $JOB_ID
+```
+
+**Expected Results:**
+- ✅ Status updates correctly on each `ferri ps` call
+- ✅ Final status is "Completed"
+- ✅ Full story is retrieved
+
+---
+
+## Test 4: Verify Job Files Created Correctly
+
+```bash
+# Run a simple job
+ferri run --model gemma -- "Count to 5"
+
+# Get the job ID
+JOB_ID=$(cat .ferri/jobs.json | grep '"id"' | tail -1 | cut -d'"' -f4)
+
+# Wait for completion
+sleep 5
+
+# Check files were created
+ls -la .ferri/jobs/$JOB_ID/
+
+# Expected files:
+# - stdout.log (contains the output)
+# - stderr.log (should be empty or minimal)
+
+# Check stdout content
+cat .ferri/jobs/$JOB_ID/stdout.log
+
+# Verify ferri ps shows completed
+ferri ps
+```
+
+**Expected Results:**
+- ✅ Job directory exists with stdout.log and stderr.log
+- ✅ stdout.log contains the model output
+- ✅ Status shows "Completed" in `ferri ps`
+
+---
+
+## Debugging
+
+If jobs stay "Running":
+
+```bash
+# Check if process still exists
+ps aux | grep -i ollama
+ps aux | grep -i ferri
+
+# Check job files
+ls -la .ferri/jobs/job-*/
+
+# Check jobs.json directly
+cat .ferri/jobs.json | tail -30
+
+# Check stdout/stderr logs
+cat .ferri/jobs/job-*/stdout.log
+cat .ferri/jobs/job-*/stderr.log
+
+# Check if PID is still valid
+cat .ferri/jobs.json | grep '"pid"' | tail -1
+```
+
+---
+
+## Success Criteria
+
+All of the following must work:
+
+1. ✅ Local (Ollama) jobs complete and update status
+2. ✅ Multiple concurrent jobs all transition correctly
+3. ✅ `ferri ps` shows accurate real-time status
+4. ✅ `ferri yank` retrieves all outputs successfully
+5. ✅ Job files (stdout.log, stderr.log) are created properly
+
+---
+
+## Known Limitations
+
+- ❌ Remote models (Gemini, etc.) are not yet supported in `ferri run`
+- ✅ Only local Ollama models work with background jobs currently

--- a/project_resources/quality/test_ferri_run_status.md
+++ b/project_resources/quality/test_ferri_run_status.md
@@ -1,0 +1,161 @@
+# Test Instructions: Ferri Run Status Updates
+
+## Objective
+
+Verify that `ferri run` jobs properly transition from "Running" to "Completed" status and that output can be retrieved.
+
+---
+
+## Setup: Create Clean Test Environment
+
+```bash
+# Create a fresh test directory
+mkdir -p /tmp/ferri-status-test-$(date +%s)
+cd /tmp/ferri-status-test-$(date +%s)
+
+# Initialize ferri
+ferri init
+```
+
+---
+
+## Test 1: Simple Command Status Transition
+
+```bash
+# Run a simple command
+ferri run -- echo "test output"
+
+# Wait 1 second for it to complete
+sleep 1
+
+# Check status in jobs.json directly
+cat .ferri/jobs.json | grep -A 5 "status"
+
+# Also check with ferri ps
+ferri ps
+```
+
+### Expected Results:
+- ✅ `jobs.json` shows `"status": "Completed"`
+- ✅ `ferri ps` displays the job as "Completed"
+- ✅ `ferri yank <job-id>` returns "test output"
+
+---
+
+## Test 2: Verify Job Files
+
+```bash
+# Check what files were created
+ls -la .ferri/jobs/job-*/
+
+# Expected files:
+# - stdout.log (should contain "test output")
+# - stderr.log (should be empty)
+# - exit_code.log (should contain "0")
+```
+
+### Verify File Contents:
+
+```bash
+# Get the job ID from the previous test
+JOB_ID=$(cat .ferri/jobs.json | grep '"id"' | tail -1 | cut -d'"' -f4)
+
+# Check stdout
+cat .ferri/jobs/$JOB_ID/stdout.log
+
+# Check exit code
+cat .ferri/jobs/$JOB_ID/exit_code.log
+
+# Retrieve via yank
+ferri yank $JOB_ID
+```
+
+---
+
+## Test 3: Failed Command Handling
+
+```bash
+# Run a command that fails
+ferri run -- bash -c "echo 'Error!' >&2; exit 1"
+
+# Wait for completion
+sleep 1
+
+# Check status
+cat .ferri/jobs.json | tail -20
+```
+
+### Expected Results:
+- ✅ Status shows "Failed" (not "Running")
+- ✅ `error_preview` field contains error message
+- ✅ `ferri ps` shows job as "Failed"
+
+---
+
+## Test 4: Multiple Concurrent Jobs
+
+```bash
+# Launch 3 jobs
+ferri run -- bash -c "sleep 1; echo 'Job 1'"
+ferri run -- bash -c "sleep 1; echo 'Job 2'"
+ferri run -- bash -c "sleep 1; echo 'Job 3'"
+
+# Check initial status (should all be Running)
+ferri ps
+
+# Wait for completion
+sleep 2
+
+# Check final status (should all be Completed)
+ferri ps
+
+# Verify all outputs
+ferri yank $(cat .ferri/jobs.json | grep '"id"' | tail -3 | head -1 | cut -d'"' -f4)
+ferri yank $(cat .ferri/jobs.json | grep '"id"' | tail -2 | head -1 | cut -d'"' -f4)
+ferri yank $(cat .ferri/jobs.json | grep '"id"' | tail -1 | cut -d'"' -f4)
+```
+
+---
+
+## Debugging: If Status Stuck at "Running"
+
+```bash
+# Check if exit_code.log was created
+ls -la .ferri/jobs/job-*/
+
+# Check for monitor thread errors
+cat .ferri/jobs/job-*/thread_error.log 2>/dev/null || echo "No error log"
+
+# Check if process is still running
+ps aux | grep [e]cho
+
+# Manual status check
+cat .ferri/jobs.json | jq '.[] | {id, status, pid}'
+```
+
+---
+
+## Report Back
+
+After running these tests, report:
+
+1. **Status in `jobs.json`**: Does it say "Completed" or still "Running"?
+2. **`ferri ps` output**: What statuses do you see?
+3. **Files in job directory**: Which files exist? (`ls -la .ferri/jobs/job-*/`)
+4. **Exit code file**: Does `exit_code.log` exist? What's in it?
+5. **Thread errors**: Any `thread_error.log` files?
+
+---
+
+## Known Issues
+
+### macOS Threading Issues
+- Spawning from background threads can hang
+- `Child.wait()` in threads can deadlock
+- Current solution: Poll by PID using `sysinfo`
+
+### If Status Never Updates
+This indicates the monitor thread is not completing. Possible causes:
+- PID polling loop not finding process exit
+- File I/O error when writing `exit_code.log`
+- Race condition between process exit and status check


### PR DESCRIPTION
## Summary
- Add `oktryitnow.md` with comprehensive Ollama job testing walkthrough
- Add `test_ferri_run_status.md` with detailed status transition verification steps
- Documents known limitation: remote models not yet supported in background jobs
- Provides debugging steps for stuck "Running" status

## Test plan
These are documentation files, no functional changes.

## Related
Companion documentation for #13 (fix for #12)