### PR TITLE
feat(engine): #48 Define the core Executor trait

### DIFF
--- a/crates/ferri-automation/src/executors.rs
+++ b/crates/ferri-automation/src/executors.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use crate::models::Workload;
+
+/// A standardized representation of an execution's status.
+pub enum ExecutionStatus {
+    Running,
+    Succeeded,
+    Failed,
+}
+
+/// A handle to a running execution, allowing for status checks and log retrieval.
+pub struct ExecutionHandle(String);
+
+/// Contains handles to resources prepared for execution.
+pub struct ExecutionContext;
+
+/// The core trait defining the contract for all executors.
+pub trait Executor {
+    fn prepare(&self, workload: &Workload, workspace: &Workspace) -> Result<ExecutionContext>;
+    fn execute(&self, context: ExecutionContext) -> Result<ExecutionHandle>;
+    fn get_status(&self, handle: &ExecutionHandle) -> Result<ExecutionStatus>;
+    fn get_logs(&self, handle: &ExecutionHandle) -> Result<Box<dyn std::io::Read>>;
+    fn cleanup(&self, context: ExecutionContext) -> Result<()>;
+}
+
+pub struct Workspace;

--- a/crates/ferri-automation/src/lib.rs
+++ b/crates/ferri-automation/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod execute;
 pub mod expressions;
+pub mod executors;
 pub mod flow;
 pub mod jobs;
+pub mod models;
 pub mod orchestrator;

--- a/crates/ferri-automation/src/models.rs
+++ b/crates/ferri-automation/src/models.rs
@@ -1,0 +1,3 @@
+pub struct Workload {
+    pub command: String,
+}


### PR DESCRIPTION
This PR introduces the foundational abstractions for the pluggable executor model as outlined in the architectural blueprint. It defines the core `Executor` trait and the `Workload` struct. This is the first step in implementing the plan from issue #48.