### PR TITLE
feat(schema): #49 Define 'outputs' and 'runs-on' fields

### DIFF
--- a/crates/ferri-automation/src/flow.rs
+++ b/crates/ferri-automation/src/flow.rs
@@ -152,7 +152,8 @@ pub struct Job {
     pub name: Option<String>,
 
     /// Runner environment (e.g., "ubuntu-latest")
-    pub runs_on: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runs_on: Option<String>,
 
     /// Job IDs that must complete before this job starts
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -182,6 +183,10 @@ pub struct Step {
     /// Reusable action to execute (mutually exclusive with 'run')
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uses: Option<String>,
+    
+    /// Declared output artifacts or files the task is expected to produce.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<String>>,
 
     /// Input parameters for the action specified by 'uses'
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This PR implements the schema changes for issue #49. It updates the `ferri-flow.yml` schema to: 1. Add an optional `outputs` field to the `Step` struct. 2. Make the `runs_on` field in the `Job` struct optional. This aligns the schema with the architectural blueprint for the pluggable executor model.